### PR TITLE
Prefer Python 2[.7] when multiple Python versions are available

### DIFF
--- a/cmake/macros.cmake
+++ b/cmake/macros.cmake
@@ -1,3 +1,4 @@
+set(Python_ADDITIONAL_VERSIONS "2.7" "2.6")
 
 find_package (PythonLibs)
 find_package (PythonInterp)


### PR DESCRIPTION
This stops build errors when building on a system where the default Python is Python 3
