### PR TITLE
Fix some compiler warnings

### DIFF
--- a/libsaxsimage/fortran/fsaxsimage.f90
+++ b/libsaxsimage/fortran/fsaxsimage.f90
@@ -159,8 +159,8 @@ CONTAINS
     INTERFACE
       FUNCTION c_saxs_image_width(img) &
                  BIND(C, NAME="saxs_image_width")
-        IMPORT C_LONG, C_PTR
-        INTEGER(C_LONG)    :: c_saxs_image_width
+        IMPORT C_SIZE_T, C_PTR
+        INTEGER(C_SIZE_T)  :: c_saxs_image_width
         TYPE(C_PTR), VALUE :: img
       END FUNCTION
     END INTERFACE
@@ -174,8 +174,8 @@ CONTAINS
     INTERFACE
       FUNCTION c_saxs_image_height(img) &
                  BIND(C, NAME="saxs_image_height")
-        IMPORT C_LONG, C_PTR
-        INTEGER(C_LONG)    :: c_saxs_image_height
+        IMPORT C_SIZE_T, C_PTR
+        INTEGER(C_SIZE_T)  :: c_saxs_image_height
         TYPE(C_PTR), VALUE :: img
       END FUNCTION
     END INTERFACE

--- a/libsaxsimage/src/tiff.c
+++ b/libsaxsimage/src/tiff.c
@@ -237,8 +237,13 @@ int saxs_image_tiff_read(saxs_image *image, const char *filename, size_t frame) 
 #undef SET_VALUE
 
   } else if (spp == 3) {
-    unsigned char *rgb = (char *)(data) + (y * width + x)*3;
-    saxs_image_set_value(image, x, height - y - 1, (rgb[0]*11 + rgb[1]*16 + rgb[2]*5)/32);
+    for (x = 0; x < width; ++x) {
+      for (y = 0; y < height; ++y) {
+        unsigned char *rgb = ((unsigned char *)data) + (y * width + x)*3;
+        int r=rgb[0], g=rgb[1], b=rgb[2];
+        saxs_image_set_value(image, x, height - y - 1, (r*11 + g*16 + b*5)/32.0);
+      }
+    }
   }
 
   TIFFClose(tiff);


### PR DESCRIPTION
The change in tiff.c looks like it fixes an actual bug; the change in fsaxsimage.f90 should prevent bugs in the case that size_t is a different size from long int.
