### PR TITLE
Don't re-read the current frame

### DIFF
--- a/libsaxsimage/src/saxsimage.c
+++ b/libsaxsimage/src/saxsimage.c
@@ -204,6 +204,9 @@ saxs_image_read_frame(saxs_image *image, size_t frame) {
   if (frame > saxs_image_frame_count(image))
     return EINVAL;
 
+  if (frame == image->image_current_frame)
+    return 0;
+
   return image->image_format->read(image, image->image_filename, frame);
 }
 


### PR DESCRIPTION
radaver currently spends 60% of its execution time (for a
single-frame Pilatus image) reading the image - 30% reading
it for saxs_image_read, and another 30% re-reading the same
image for saxs_image_read_frame.
