### PR TITLE
For single-frame image formats, fail if requesting a frame number other than 1

### DIFF
--- a/libsaxsimage/src/cbf.c
+++ b/libsaxsimage/src/cbf.c
@@ -96,6 +96,10 @@ int saxs_image_cbf_read(saxs_image *image, const char *filename, size_t frame) {
   cbf_handle cbf;
   FILE *fd;
 
+  /* CBF images have only one frame */
+  if (frame != 1)
+    return -2;
+
   /* The 'b' is required for windows, overwise reading fails. */
   fd = fopen(filename, "rb");
   if (!fd)

--- a/libsaxsimage/src/edf.c
+++ b/libsaxsimage/src/edf.c
@@ -38,6 +38,10 @@ int saxs_image_edf_read(saxs_image *image, const char *filename, size_t frame) {
                           holds number of elements to follow */
   size_t size;         /* number of data elements */
 
+  /* EDF images have only one frame */
+  if (frame != 1)
+    return -2;
+
   fd = edf_open_data_file(filename, "old", &edf_errno, &status);
   if (status) {
     fd = -1;

--- a/libsaxsimage/src/msk.c
+++ b/libsaxsimage/src/msk.c
@@ -40,6 +40,10 @@ int saxs_image_msk_read(saxs_image *image, const char *filename, size_t frame) {
   int width, height, padding;
   int row, col, bit;
 
+  /* msk images have only one frame */
+  if (frame != 1)
+    return -2;
+
   FILE *fd = fopen(filename, "rb");
   if (!fd)
     return errno;

--- a/libsaxsimage/src/tiff.c
+++ b/libsaxsimage/src/tiff.c
@@ -166,6 +166,10 @@ int saxs_image_tiff_read(saxs_image *image, const char *filename, size_t frame) 
   uint16 bpp, spp, format;
   uint32 width, height, x, y;
 
+  /* TIFF images have only one frame */
+  if (frame != 1)
+    return -2;
+
   tiff_initialize();
 
   tiff = TIFFOpen(filename, "r");


### PR DESCRIPTION
This also stops the compiler complaining about unused arguments
