### PR TITLE
pysaxsdocument: Allow multithreading

### DIFF
--- a/libsaxsdocument/python/ChangeLog
+++ b/libsaxsdocument/python/ChangeLog
@@ -1,3 +1,7 @@
+2016-07-13  Chris Kerr  <ckerr@embl-hamburg.de>
+
+        * pysaxsdocument.c: Release the GIL while calling the C library functions
+
 2016-07-07  Chris Kerr  <ckerr@embl-hamburg.de>
 
         * CMakeLists.txt: Python executable is not necessary to build python modules

--- a/libsaxsdocument/python/pysaxsdocument.c
+++ b/libsaxsdocument/python/pysaxsdocument.c
@@ -112,8 +112,11 @@ PySaxsDocument_Read(const char *filename, const char *format,
   saxs_property *property;
   int res;
 
+  Py_BEGIN_ALLOW_THREADS
   doc = saxs_document_create();
   res = saxs_document_read(doc, filename, format);
+  Py_END_ALLOW_THREADS
+
   if (res != 0) {
     saxs_document_free(doc);
     return PyErr_Format(PyExc_IOError, "%s: %s", filename, strerror(res));


### PR DESCRIPTION
Release the Python GIL when calling saxs_document_read()
This allows (partly) multithreaded parallel reading of saxsdocument files
