### PR TITLE
Fixed -Wmissing-field-initializers warning in pysaxsdocument.c

### DIFF
--- a/libsaxsdocument/python/pysaxsdocument.c
+++ b/libsaxsdocument/python/pysaxsdocument.c
@@ -44,7 +44,7 @@ typedef struct {
 } PySaxsDocumentObject;
 
 PyTypeObject PySaxsDocument_Type  = {
-  PyObject_HEAD_INIT(NULL)
+  PyVarObject_HEAD_INIT(NULL, 0)
 };
 
 static void


### PR DESCRIPTION
PyTypeObject needs the 'ob_size' field to be initialised