### PR TITLE
Fixed crash in Malvern txt parser

### DIFF
--- a/libsaxsdocument/src/malvern_txt.c
+++ b/libsaxsdocument/src/malvern_txt.c
@@ -203,8 +203,11 @@ malvern_txt_parse_data(struct saxs_document *doc,
     res = malvern_txt_parse_column_values(firstline, &values, &ndata);
     if (res)
       goto exit;
-    if (ndata > 2*nhdr)
+    if (ndata > 2*nhdr) {
+      free(values);
+      res = ENOTSUP;
       goto exit;
+    }
 
     for (i = 1; i < ndata; ++i)
       saxs_curve_add_data(curves[i], values[0], 0.0, values[i], 0.0);

--- a/libsaxsdocument/src/malvern_txt.c
+++ b/libsaxsdocument/src/malvern_txt.c
@@ -144,7 +144,8 @@ malvern_txt_parse_data(struct saxs_document *doc,
                        const struct line *firstline,
                        const struct line *lastline) {
 
-  int i, j, n;
+  int i, j;
+  int nhdr, ndata;
   char **headers = NULL;
   double *values = NULL;
 
@@ -163,7 +164,7 @@ malvern_txt_parse_data(struct saxs_document *doc,
   struct saxs_curve **curves = NULL;
 
   /* The list of column names. */
-  res = malvern_txt_parse_column_headers(firstline, &headers, &n);
+  res = malvern_txt_parse_column_headers(firstline, &headers, &nhdr);
   if (res)
     return res;
   firstline = firstline->next;
@@ -177,12 +178,12 @@ malvern_txt_parse_data(struct saxs_document *doc,
     res = ENOMEM;
     goto exit;
   }
-  curves = (struct saxs_curve **) malloc(2 * n * sizeof(struct saxs_curve*));
+  curves = (struct saxs_curve **) malloc(2 * nhdr * sizeof(struct saxs_curve*));
   if (!curves) {
     res = ENOMEM;
     goto exit;
   }
-  for (i = 0; i < 2*n; ++i) {
+  for (i = 0; i < 2*nhdr; ++i) {
     curves[i] = saxs_document_add_curve(tmpdoc, "tmp",
                                         SAXS_CURVE_EXPERIMENTAL_SCATTERING_DATA);
     if (!curves[i]) {
@@ -199,10 +200,13 @@ malvern_txt_parse_data(struct saxs_document *doc,
    * it should be the retention volume.
    */
   while (firstline != lastline) {
-    res = malvern_txt_parse_column_values(firstline, &values, &n);
+    res = malvern_txt_parse_column_values(firstline, &values, &ndata);
     if (res)
       goto exit;
-    for (i = 1; i < n; ++i)
+    if (ndata > 2*nhdr)
+      goto exit;
+
+    for (i = 1; i < ndata; ++i)
       saxs_curve_add_data(curves[i], values[0], 0.0, values[i], 0.0);
 
     free(values);
@@ -238,7 +242,7 @@ malvern_txt_parse_data(struct saxs_document *doc,
 exit:
   saxs_document_free(tmpdoc);
 
-  for (i = 0; i < n; ++i)
+  for (i = 0; i < nhdr; ++i)
     free(headers[i]);
 
   free(headers);

--- a/testsuite/libsaxsdocument/crashtests/CMakeLists.txt
+++ b/testsuite/libsaxsdocument/crashtests/CMakeLists.txt
@@ -9,3 +9,6 @@ add_test (NAME libsaxsdocument-crashtest-02
 
 add_test (NAME libsaxsdocument-crashtest-03
           COMMAND $<TARGET_FILE:readtest> "${CMAKE_CURRENT_SOURCE_DIR}/crash03.dat")
+
+add_test (NAME libsaxsdocument-crashtest-04
+          COMMAND $<TARGET_FILE:readtest> "${CMAKE_CURRENT_SOURCE_DIR}/crash04.txt")

--- a/testsuite/libsaxsdocument/crashtests/crash04.txt
+++ b/testsuite/libsaxsdocument/crashtests/crash04.txt
@@ -1,0 +1,2 @@
+Adjusted UVAdjusted RI
+0		


### PR DESCRIPTION
There was a buffer overrun when the number of data columns did not match the number of headers