### PR TITLE
Fixed assertion error in Malvern parser

### DIFF
--- a/libsaxsdocument/src/malvern_txt.c
+++ b/libsaxsdocument/src/malvern_txt.c
@@ -99,31 +99,31 @@ malvern_txt_parse_column_headers(const struct line *l, char ***columns, int *n) 
 
 static int
 malvern_txt_parse_column_values(const struct line *l, double **values, int *n) {
-  *n = malvern_txt_count_columns(l);
-  *values = (double*)malloc(*n * sizeof(double));
+  int ncols = malvern_txt_count_columns(l);
+  *values = (double*)malloc(ncols * sizeof(double));
   if (*values == NULL)
     return ENOMEM;
 
-  if (*n > 0) {
-    int k = 0;
-    char *p = l->line_buffer;
+  int k = 0;
+  char *p = l->line_buffer;
 
-    while (*p) {
-      if (sscanf(p, "%lf", &(*values)[k]) != 1)
-        break;
+  for (k=0; k<ncols; ++k) {
+    if (sscanf(p, "%lf", &(*values)[k]) != 1)
+      break;
+    if (isinf((*values)[k]) || isnan((*values)[k]))
+      break;
 
-      k += 1;
+    /* Skip leading whitespace, if any. */
+    while (*p && isspace(*p)) ++p;
 
-      /* Skip leading whitespace, if any. */
-      while (*p && isspace(*p)) ++p;
+    /* Skip the floating point value until the next separator is found. */
+    while (*p && !isspace(*p)) ++p;
 
-      /* Skip the floating point value until the next separator is found. */
-      while (*p && !isspace(*p)) ++p;
-
-      /* Skip all consecutive separators up to the next value (think " , "). */
-      while (*p && isspace(*p)) ++p;
-    }
+    /* Skip all consecutive separators up to the next value (think " , "). */
+    while (*p && isspace(*p)) ++p;
   }
+
+  *n = k;
   return 0;
 }
 

--- a/testsuite/libsaxsdocument/crashtests/CMakeLists.txt
+++ b/testsuite/libsaxsdocument/crashtests/CMakeLists.txt
@@ -12,3 +12,6 @@ add_test (NAME libsaxsdocument-crashtest-03
 
 add_test (NAME libsaxsdocument-crashtest-04
           COMMAND $<TARGET_FILE:readtest> "${CMAKE_CURRENT_SOURCE_DIR}/crash04.txt")
+
+add_test (NAME libsaxsdocument-crashtest-05
+          COMMAND $<TARGET_FILE:readtest> "${CMAKE_CURRENT_SOURCE_DIR}/crash05.txt")

--- a/testsuite/libsaxsdocument/crashtests/crash05.txt
+++ b/testsuite/libsaxsdocument/crashtests/crash05.txt
@@ -1,0 +1,1 @@
+Adjusted RIAdjusted RALS1E1000	


### PR DESCRIPTION
The Malvern parser didn't check for infinity / NaN, and also had a potential buffer overflow.